### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+MIT License
+
+Copyright (c) 2025 Arkadia Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+


### PR DESCRIPTION
📄 PR Description – Add MIT License
🔗 Related Issue

Closes #1 (🚫 License Missing from Repository)

🎯 Rationale

The repository currently does not have a license.

Adding the MIT License ensures that contributors and users clearly understand the permissions and limitations of using this project.

MIT is simple, widely adopted, and suitable for open-source communities like Arkadia.

📝 Summary of Changes

Added a new file: LICENSE at the root of the project.

License text: MIT License with copyright attribution to Arkadia Community (2025).

📚 Documentation

Contributors can freely use, modify, and distribute the code under MIT terms.

The README will automatically reflect the license via badge.

✅ Checklist

 LICENSE file added

 MIT License text included

 Copyright set to Arkadia Community (2025)

 PR linked to related issue